### PR TITLE
Save results directly to output directory with compression

### DIFF
--- a/jobcreator/_job_templates/caiman_template.py
+++ b/jobcreator/_job_templates/caiman_template.py
@@ -80,7 +80,7 @@ echo "analysis"
 source activate {environment}
 conda env export > {env_file_stub}$SLURM_JOBID_env.yml
 
-caiman_runner --file $TMP --ncpus {n_cpu} --mc_settings {mc_settings_file} --cnmf_settings {cnmf_settings_file} --qc_settings {qc_settings_file} --output {jobcreator_output_dir} {mcorr_flag}
+caiman_runner --file $TMP --ncpus {n_cpu} --mc_settings {mc_settings_file} --cnmf_settings {cnmf_settings_file} --qc_settings {qc_settings_file} --output {jobcreator_output_dir} --job_name {job_name} {mcorr_flag}
 
 """
 
@@ -164,7 +164,7 @@ pip freeze > "{env_file_stub}$SLURM_JOB_ID$env_file_extension"
 for file in {data_pattern}; do cp "$file" {jobcreator_output_dir};done
 
 echo "analysis"
-caiman_runner --file {jobcreator_output_dir} --ncpus {n_cpu} --mc_settings {mc_settings_file} --cnmf_settings {cnmf_settings_file} --qc_settings {qc_settings_file} --output {jobcreator_output_dir} {mcorr_flag}
+caiman_runner --file {jobcreator_output_dir} --ncpus {n_cpu} --mc_settings {mc_settings_file} --cnmf_settings {cnmf_settings_file} --qc_settings {qc_settings_file} --output {jobcreator_output_dir} --job_name {job_name} {mcorr_flag}
 
 # remove the copied raw movies and memmap files
 rm {jobcreator_output_dir}/*.tif*

--- a/jobcreator/_job_templates/caiman_template.py
+++ b/jobcreator/_job_templates/caiman_template.py
@@ -82,8 +82,6 @@ conda env export > {env_file_stub}$SLURM_JOBID_env.yml
 
 caiman_runner --file $TMP --ncpus {n_cpu} --mc_settings {mc_settings_file} --cnmf_settings {cnmf_settings_file} --qc_settings {qc_settings_file} --output {jobcreator_output_dir} {mcorr_flag}
 
-for file in $TMP/*.hdf5; do cp "$file" {jobcreator_output_dir};done
-for file in $TMP/*.pkl; do cp "$file" {jobcreator_output_dir};done
 """
 
     return job_file

--- a/jobcreator/_pipeline_runners/caiman_runner.py
+++ b/jobcreator/_pipeline_runners/caiman_runner.py
@@ -215,6 +215,7 @@ def run(
             memmap_files=memmap_files,
             frame_shape=cnm_results.dims,
             dataset_name=dataset_name,
+            compression='gzip',
         )
 
     # save the parameters in the same dir as the results

--- a/jobcreator/_pipeline_runners/caiman_runner.py
+++ b/jobcreator/_pipeline_runners/caiman_runner.py
@@ -215,7 +215,7 @@ def run(
             memmap_files=memmap_files,
             frame_shape=cnm_results.dims,
             dataset_name=dataset_name,
-            compression='gzip',
+            compression="gzip",
         )
 
     # save the parameters in the same dir as the results

--- a/jobcreator/_pipeline_runners/caiman_runner.py
+++ b/jobcreator/_pipeline_runners/caiman_runner.py
@@ -152,7 +152,7 @@ def run(
         fnames = [file_path]
     else:
         file_pattern = os.path.join(file_path, "*.tif*")
-        fnames = glob.glob(file_pattern).sort()
+        fnames = sorted(glob.glob(file_pattern))
     print(fnames)
     opts.set("data", {"fnames": fnames})
 
@@ -209,7 +209,7 @@ def run(
                 memmap_pattern = base_file + "*_els_*"
             else:
                 memmap_pattern = base_file + "*_rig_*"
-            memmap_files += glob.glob(memmap_pattern).sort()
+            memmap_files += sorted(glob.glob(memmap_pattern))
         write_hdf5_movie(
             movie_name=mcorr_fname,
             memmap_files=memmap_files,


### PR DESCRIPTION
This PR adds:
- Results files are now saved directly to the output folder (used to saved in TMP and copied)
- Motion corrected movie is compressed with gzip (level 4)