### PR TITLE
update set-env

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Get version from tag
         run: |
           TAG="${GITHUB_REF/refs\/tags\/v/}"
-          echo "::set-env name=tag::$TAG"
+          echo "tag=${TAG}" >> $GITHUB_ENV
       - name: Checkout code
         uses: actions/checkout@master
       - name: Install Python


### PR DESCRIPTION
This PR updates the github actions for release in light of the set-env deprecation: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/